### PR TITLE
This commit fixes various compiler warnings on the example code.

### DIFF
--- a/docs/src/cbmc/overview/Proof-harnesses.md
+++ b/docs/src/cbmc/overview/Proof-harnesses.md
@@ -43,7 +43,7 @@ is an integer `b`.  We write a proof harness [harness1.c](examples/harness/harne
 ```c
 int beta1(int b);
 
-main() {
+int main() {
    int x;
    beta1(x);
 }
@@ -112,7 +112,7 @@ We write a proof harness [harness2.c](examples/harness/harness2.c)
 extern int counter;
 int beta2(int b);
 
-main() {
+int main() {
     int cnt;
     counter = cnt;
 
@@ -189,7 +189,7 @@ We write the proof harness [harness3.c](examples/harness/harness3.c)
 ```c
 int alpha(int x);
 
-main() {
+int main() {
     int x;
     alpha(x);
 }
@@ -285,7 +285,7 @@ strbuf* strbuf_allocate(size_t length) {
 Now we can write a proof harness for the function
 
 ```c
-main() {
+int main() {
   size_t len;
   strbuf* str = strbuf_allocate(len);
 
@@ -341,7 +341,7 @@ In fact, we can prove the this remains true after the function invocation,
 meaning that the function preserves the validity of its input.
 
 ```c
-main() {
+int main() {
   size_t len;
   strbuf* str = strbuf_allocate(len);
 

--- a/docs/src/cbmc/overview/checking-properties.md
+++ b/docs/src/cbmc/overview/checking-properties.md
@@ -23,7 +23,7 @@ For the full list of things that CBMC can check, run `cbmc --help`.
 
 Given the program [`bounds.c`](examples/properties/bounds.c)
 ```c
-main() {
+int main() {
   int array[10];
   for (int i=0; i<=10; i++) array[i] = i;
 }
@@ -40,7 +40,7 @@ line 3 array 'array' upper bound in array[(signed long int)i]: FAILURE
 
 Given the program [`pointers.c`](examples/properties/pointers.c)
 ```
-main() {
+int main() {
   int *ptr;
   int array[10];
   *ptr = 3;
@@ -83,7 +83,7 @@ We always use these flags together.
 Given the file [`pointer-overflow.c`](examples/properties/pointer-overflow.c)
 ```
 #include <stdint.h>
-main() {
+int main() {
   int array[10];
   int *x = array + SIZE_MAX;
 }
@@ -163,7 +163,7 @@ line 4 dereference failure: invalid integer address in *x: SUCCESS
 Given the file [integer.c](examples/properties/integer.c)
 ```
 #include <limits.h>
-main() {
+int main() {
   int x;
   int y;
   if (x + y <= INT_MAX)
@@ -191,7 +191,7 @@ line 8 arithmetic overflow on signed + in x + y: FAILURE
 
 Given the file [`float.c`](examples/properties/float.c)
 ```
-main() {
+int main() {
   float x = 100000000.0;
   for (int i = 0; i < 10; i++) x = x * x;
 }
@@ -211,7 +211,7 @@ line 3 arithmetic overflow on floating-point multiplication in x * x: FAILURE
 
 Given the file [`nan.c`](examples/properties/nan.c)
 ```
-main() {
+int main() {
   float x = 0.0 / 0.0;
 }
 ```
@@ -234,7 +234,7 @@ line 2 NaN on / in 0.0 / 0.0: FAILURE
 
 Given the file [`zero.c`](examples/properties/zero.c)
 ```
-main() {
+int main() {
   int a;
   int b;
   int result = a / b;
@@ -258,7 +258,7 @@ line 4 division by zero in a / b: FAILURE
 Given the file [`conversion.c`](examples/properties/conversion.c)
 ```
 #include <stdint.h>
-main() {
+int main() {
   uint8_t x;
   uint16_t y;
   x = y;
@@ -285,7 +285,7 @@ line 5 arithmetic overflow on unsigned to unsigned type conversion in (uint8_t)y
 
 Given the program ['shift.c'](examples/properties/shift.c)
 ```
-main() {
+int main() {
   int x = 1;
   int y = -1;
   int z;
@@ -321,7 +321,7 @@ Always run CBMC with the flag `--unwinding-assertions`.
 Given the program [`loop.c`](examples/properties/loop.c)
 ```
 #include <stdbool.h>
-main() {
+int main() {
   int bound;
   for (int i=0; i<bound; i++)
     if (i > 9) assert(false);

--- a/docs/src/cbmc/overview/debugging.md
+++ b/docs/src/cbmc/overview/debugging.md
@@ -14,7 +14,7 @@ char buffer[SIZE];
 char read_buffer(int i)  { return buffer[i];     }
 char read_pointer(int i) { return *(buffer + i); }
 
-main() {
+int main() {
   int index;
   read_buffer(index);
   read_pointer(index);
@@ -87,7 +87,7 @@ buffer.
 The source code in [termination.c](examples/simple/termination.c)
 ```c
 #include <stdlib.h>
-main() {
+int main() {
   size_t initial_size;
   size_t requested_size;
 

--- a/docs/src/cbmc/overview/examples/harness/harness3.c
+++ b/docs/src/cbmc/overview/examples/harness/harness3.c
@@ -3,7 +3,7 @@
 
 int alpha(int x);
 
-main() {
+int main() {
 
   int x;
   alpha(x);

--- a/docs/src/cbmc/overview/examples/simple/library.c
+++ b/docs/src/cbmc/overview/examples/simple/library.c
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-#include <stdlib.h>
 #include "library.h"
 
 #define SIZE 20
@@ -9,9 +8,9 @@ char buffer[SIZE];
 
 char read_buffer(int i)  {
   if (0 <= i && i < SIZE) return buffer[i];
-  return NULL;
+  return '\0';
 }
 char read_pointer(int i) {
   if (0 <= i && i < SIZE) return *(buffer + i);
-  return NULL;
+  return '\0';
 }

--- a/docs/src/cbmc/overview/examples/simple/memory-safety.c
+++ b/docs/src/cbmc/overview/examples/simple/memory-safety.c
@@ -7,7 +7,7 @@ char buffer[SIZE];
 char read_buffer(int i)  { return buffer[i];     }
 char read_pointer(int i) { return *(buffer + i); }
 
-main() {
+int main() {
   int index;
   read_buffer(index);
   read_pointer(index);

--- a/docs/src/cbmc/overview/examples/simple/memory-safety1.c
+++ b/docs/src/cbmc/overview/examples/simple/memory-safety1.c
@@ -1,21 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-#include <stdlib.h>
-
 #define SIZE 20
 char buffer[SIZE];
 
 char read_buffer(int i)  {
   if (i < SIZE) return buffer[i];
-  return NULL;
+  return '\0';
 }
 char read_pointer(int i) {
   if (i < SIZE) return *(buffer + i);
-  return NULL;
+  return '\0';
 }
 
-main() {
+int main() {
   int index;
   read_buffer(index);
   read_pointer(index);

--- a/docs/src/cbmc/overview/examples/simple/memory-safety2.c
+++ b/docs/src/cbmc/overview/examples/simple/memory-safety2.c
@@ -1,21 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-#include <stdlib.h>
-
 #define SIZE 20
 char buffer[SIZE];
 
 char read_buffer(int i)  {
   if (0 <= i && i < SIZE) return buffer[i];
-  return NULL;
+  return '\0';
 }
 char read_pointer(int i) {
   if (0 <= i && i < SIZE) return *(buffer + i);
-  return NULL;
+  return '\0';
 }
 
-main() {
+int main() {
   int index;
   read_buffer(index);
   read_pointer(index);

--- a/docs/src/cbmc/overview/examples/simple/termination.c
+++ b/docs/src/cbmc/overview/examples/simple/termination.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 
 #include <stdlib.h>
-main() {
+int main() {
   size_t initial_size;
   size_t requested_size;
 

--- a/docs/src/cbmc/overview/goto-programs.md
+++ b/docs/src/cbmc/overview/goto-programs.md
@@ -37,7 +37,7 @@ int beta(int x) {
   return x+2;
 }
 
-main() {
+int main() {
   int (*function)();
 
   int bool;

--- a/docs/src/cbmc/overview/proof.md
+++ b/docs/src/cbmc/overview/proof.md
@@ -26,7 +26,7 @@ char buffer[SIZE];
 char read_buffer(int i)  { return buffer[i];     }
 char read_pointer(int i) { return *(buffer + i); }
 
-main() {
+int main() {
   int index;
   read_buffer(index);
   read_pointer(index);
@@ -41,21 +41,19 @@ in the code.  Let's fix that.
 Let's try adding bounds checking.
 Consider [memory-safety1.c](examples/simple/memory-safety1.c)
 ```c
-#include <stdlib.h>
-
 #define SIZE 20
 char buffer[SIZE];
 
 char read_buffer(int i)  {
   if (i < SIZE) return buffer[i];
-  return NULL;
+  return '\0';
 }
 char read_pointer(int i) {
   if (i < SIZE) return *(buffer + i);
-  return NULL;
+  return '\0';
 }
 
-main() {
+int main() {
   int index;
   read_buffer(index);
   read_pointer(index);
@@ -89,21 +87,19 @@ Oh, nuts.  We failed.  We added bounds checking only for the upper bound.
 Let's try adding bounds checking for both the upper and lower bounds.
 Consider [memory-safety2.c](examples/simple/memory-safety2.c)
 ```c
-#include <stdlib.h>
-
 #define SIZE 20
 char buffer[SIZE];
 
 char read_buffer(int i)  {
   if (0 <= i && i < SIZE) return buffer[i];
-  return NULL;
+  return '\0';
 }
 char read_pointer(int i) {
   if (0 <= i && i < SIZE) return *(buffer + i);
-  return NULL;
+  return '\0';
 }
 
-main() {
+int main() {
   int index;
   read_buffer(index);
   read_pointer(index);
@@ -185,7 +181,6 @@ char read_pointer(int i);
 ```
 and [library.c](examples/simple/library.c)
 ```c
-#include <stdlib.h>
 #include "library.h"
 
 #define SIZE 20
@@ -193,11 +188,11 @@ char buffer[SIZE];
 
 char read_buffer(int i)  {
   if (0 <= i && i < SIZE) return buffer[i];
-  return NULL;
+  return '\0';
 }
 char read_pointer(int i) {
   if (0 <= i && i < SIZE) return *(buffer + i);
-  return NULL;
+  return '\0';
 }
 ```
 

--- a/docs/src/faq/loop-unwinding.md
+++ b/docs/src/faq/loop-unwinding.md
@@ -99,7 +99,7 @@ it challenging to write a Makefile where arithmetic like `B+1` is difficult.
 One style we have developed is to write a proof harness
 
 ```C
-main() {
+int main() {
   size_t length;
   __CPROVER_assume(length < LENGTH);
 


### PR DESCRIPTION
*Description of changes:*

This PR eliminates multiple compiler warnings that you will see if you try
the examples with "gcc -Wall". In general we should be publishing
warning free code as examples.

1. "NULL" is not a suitable value for a char. Assigning NULL to a char
(or returning NULL from a char typed function) gets you a warning and
will ultimately result in a truncated zero value, the same value you would
get if you used the 0 char value '\0';

2. The compiler will give you a warning if don't give functions a return type.
If you don't it will assume you meant "int". This fix explictly uses "int" to
resolve the warning. This is the right thing to do for instances of the "main"
function that lacked a type. I also did it for the "harness" function for
consistency, but you could argue, and I perhaps would, that "void" would
have been more appropriate.

3. There are various files that #included stdlib.h, but only so they could
use NULL, but since NULL should not have been used the #include can be
removed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
